### PR TITLE
Fixed borrowing violation in `test_dec_quad_get_coefficient`

### DIFF
--- a/src/dec_double_c.rs
+++ b/src/dec_double_c.rs
@@ -12,7 +12,7 @@ extern "C" {
   /// Unsafe binding to *decDoubleToString* function.
   pub fn decDoubleToString(dd1: *const DecDouble, s: *mut c_char) -> *mut c_char;
   /// Unsafe binding to *decDoubleZero* function.
-  pub fn decDoubleZero(dd: *mut DecDouble);
+  pub fn decDoubleZero(dd: *mut DecDouble) -> *mut DecDouble;
 }
 
 /*

--- a/src/dec_quad.rs
+++ b/src/dec_quad.rs
@@ -328,8 +328,8 @@ pub fn dec_quad_from_wider(dq1: &DecQuad, dc: &mut DecContext) -> DecQuad {
 }
 
 /// Safe binding to *decQuadGetCoefficient* function.
-pub fn dec_quad_get_coefficient(x: &DecQuad, bcd: &[u8; DEC_QUAD_PMAX]) -> c_int {
-  unsafe { decQuadGetCoefficient(x, bcd.as_ptr()) }
+pub fn dec_quad_get_coefficient(x: &DecQuad, bcd: &mut [u8; DEC_QUAD_PMAX]) -> c_int {
+  unsafe { decQuadGetCoefficient(x, bcd.as_mut_ptr()) }
 }
 
 /// Safe binding to *decQuadGetExponent* function.

--- a/tests/dec_quad.rs
+++ b/tests/dec_quad.rs
@@ -223,8 +223,8 @@ fn test_dec_quad_from_u32() {
 
 #[test]
 fn test_dec_quad_get_coefficient() {
-  assert_eq!(0, dec_quad_get_coefficient(&n!(1), &bcd_quad(u128::MAX)));
-  assert_eq!(-2147483648, dec_quad_get_coefficient(&n!(-1), &bcd_quad(u128::MAX)));
+  assert_eq!(0, dec_quad_get_coefficient(&mut n!(1), &mut bcd_quad(u128::MAX)));
+  assert_eq!(-2147483648, dec_quad_get_coefficient(&mut n!(-1), &mut bcd_quad(u128::MAX)));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1 and adds a missing return type to the declaration for `decDoubleZero`.